### PR TITLE
Fix - Remove the quotes

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -3,10 +3,10 @@ jupyter_profile_env_dir: '{{jupyter_profile_conda_root}}/envs/{{jupyter_profile_
 jupyter_profile_install_py: '{{jupyter_profile_env_dir}}/notebook_config.py'
 
 jupyter_profile_nbextensions: >-
-  '{ "nb_conda": {{jupyter_profile_nb_conda_extension|default(True)}},
+  { "nb_conda": {{jupyter_profile_nb_conda_extension|default(True)}},
      "nb_anacondacloud": {{jupyter_profile_nb_anacondacloud_extension|default(True)}},
      "nbpresent": {{jupyter_profile_nb_present_extension|default(True)}},
-   }'
+  }
 
 jupyter_profile_default_config_options:
   - key: NotebookApp.kernel_spec_manager_class


### PR DESCRIPTION
Sorry! missed it. jupyter notebook didn't report failure until I tried opening notebook in browser.

nbextensions are required to be passed as dict not string.