### PR TITLE
Feat/allow imports in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Example Playbook
 - hosts: servers
   roles:
     - role: andrewrothstein.jupyter-profile
-	    jupyter_profile_name: my-jupyter-profile
-	    jupyter_profile_environment: my-jupyter-profile-environment.yml
+      jupyter_profile_name: my-jupyter-profile
+      jupyter_profile_environment: my-jupyter-profile-environment.yml
 ```
 
 License

--- a/README.md
+++ b/README.md
@@ -27,8 +27,8 @@ Example Playbook
 - hosts: servers
   roles:
     - role: andrewrothstein.jupyter-profile
-	  jupyter_profile_name: my-jupyter-profile
-	  jupyter_profile_environment: my-jupyter-profile-environment.yml
+	    jupyter_profile_name: my-jupyter-profile
+	    jupyter_profile_environment: my-jupyter-profile-environment.yml
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -18,6 +18,10 @@ jupyter_profile_environment: environment.yml
 # To manage list of nbextensions that are loaded, use following var
 #jupyter_profile_nbextensions: '{ "toc": True, "nbconda": True, "nb_anacondacloud": False }'
 
+# Used if you need an import in your configuration.
+# For instance os to use os.environ.get('ENV_VAR', 'default')
+#jupyter_profile_config_imports = [os]
+
 # Option to clean conda downloads and cached packages
 jupyter_profile_conda_cleanup: False
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -9,6 +9,16 @@
   args:
     creates: '{{ jupyter_profile_install_py }}'
 
+- name: set config imports
+  become: '{{ jupyter_profile_privilege_escalate|default(True) }}'
+  become_user: root
+  with_items: '{{ jupyter_profile_config_imports | default([]) }}'
+  lininfile:
+    state: present
+    dest: '{{ jupyter_profile_install_py }}'
+    insertbefore: BOF
+    line: 'import {{ item }}'
+
 - name: set jupyter configs
   become: '{{ jupyter_profile_privilege_escalate|default(True) }}'
   become_user: root

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
   become: '{{ jupyter_profile_privilege_escalate|default(True) }}'
   become_user: root
   with_items: '{{ jupyter_profile_config_imports | default([]) }}'
-  lininfile:
+  lineinfile:
     state: present
     dest: '{{ jupyter_profile_install_py }}'
     insertbefore: BOF

--- a/test.yml
+++ b/test.yml
@@ -4,3 +4,14 @@
     - role: '{{playbook_dir}}'
       jupyter_profile_name: ansible-jupyter-profile
       jupyter_profile_environment: jupyter-profile-test-environment.yml
+      jupyter_profile_config_imports: [os, time]
+    
+- hosts: all
+  tasks:
+    - name: make sure config imports are propely formatted
+      command: head -n 5 {{ jupyter_profile_install_py }} 
+      register: head_out
+
+    - name: debug
+      debug:
+        msg: "{{ head_out.stdout }}"

--- a/test.yml
+++ b/test.yml
@@ -5,13 +5,25 @@
       jupyter_profile_name: ansible-jupyter-profile
       jupyter_profile_environment: jupyter-profile-test-environment.yml
       jupyter_profile_config_imports: [os, time]
+      jupyter_profile_config_options:
+        - key: NotebookApp.base_url
+          value: os.environ.get('JUPYTER_BASE_URL', '/')
+
     
 - hosts: all
   tasks:
-    - name: make sure config imports are propely formatted
+    - name: see if config imports are propely formatted
       command: head -n 5 {{ jupyter_profile_install_py }} 
       register: head_out
 
     - name: debug
       debug:
         msg: "{{ head_out.stdout }}"
+    
+    - name: see if custom configs are propely formatted
+      command: tail -n 5 {{ jupyter_profile_install_py }} 
+      register: tail_out
+
+    - name: debug
+      debug:
+        msg: "{{ tail_out.stdout }}"


### PR DESCRIPTION
For certain use-cases one may need to inject an import to utilize it within the config file. One such example is for pulling in environment variables:

```python
import os
c.NotebookApp.base_url=os.environ.get('JUPYTER_BASE_URL', '/')
```

Technically you could inject environment variables in the start script, but i prefer having all the configs in one spot.

This was tested by utilizing this branch in an upstream ansible-jupyter build for building a notebook image